### PR TITLE
Issue-10: set the "editable" class for editable cells, so set different backgound colours

### DIFF
--- a/src/components/Cell.js
+++ b/src/components/Cell.js
@@ -27,7 +27,10 @@ const bindToKeyboardInput = () => {
 
 bindToKeyboardInput();
 
-function createClass(index, selection, prevClass) {
+function createClass(index, selection, editable, prevClass) {
+  if (editable){
+    prevClass += " editable"
+  }
   if (index % 9 === 2 || index % 9 === 5) {
     prevClass += " border-right";
   }
@@ -73,7 +76,7 @@ function Cell({ number, index, editable, status, selection }) {
   return (
     <div
       className={createClass(
-        index, selection,
+        index, selection, editable,
         !editable || number === 0
           ? "cell"
           : status

--- a/src/components/styles/Board.scss
+++ b/src/components/styles/Board.scss
@@ -56,6 +56,9 @@
                     display: grid;
                     place-content: center;
                 }
+                .editable {
+                    background-color: #ffffff;
+                }
                 .border-top {
                     border-top: 0.2vmin solid var(--wide-border-color) !important;
                 }
@@ -130,7 +133,7 @@
             }
         }
     }
-    
+
     .xeasy {
         perspective: 50vmin;
         .board {
@@ -142,7 +145,7 @@
             }
         }
     }
-    
+
     .easy {
         perspective: 50vmin;
         .board {
@@ -154,7 +157,7 @@
             }
         }
     }
-    
+
     .medium {
         perspective: 50vmin;
         .board {
@@ -166,7 +169,7 @@
             }
         }
     }
-    
+
     .hard {
         perspective: 50vmin;
         .board {
@@ -178,11 +181,11 @@
             }
         }
     }
-    
+
     .hidden {
         display: none !important;
     }
-    
+
     .done {
         perspective: 100vmin;
         transition: 2s ease;
@@ -215,7 +218,7 @@
             }
         }
     }
-    
+
     @keyframes frame1 {
         0% {
             transform: rotateX(-180deg) rotateY(0deg) rotateZ(0deg);
@@ -227,7 +230,7 @@
             transform: rotateX(-90deg) rotateY(0deg) rotateZ(36000deg);
         }
     }
-    
+
     @keyframes fade {
         0% {
             opacity: 1;
@@ -236,7 +239,7 @@
             opacity: 0;
         }
     }
-    
+
     .controls {
         transition: 1s ease;
         height: 50vmin;
@@ -324,7 +327,7 @@
             }
         }
     }
-    
+
     .numpad {
         background: #81A1C1;
         position: absolute;
@@ -341,12 +344,12 @@
             font-size: 2em;
         }
     }
-    
+
     .tooltip {
         font-family: 'Roboto Mono', monospace;
         position: relative;
     }
-    
+
     .tooltiptext {
         position: absolute;
         visibility: hidden;
@@ -361,7 +364,7 @@
         z-index: 1;
         transform: translate(90%,300%);
     }
-    
+
     .tooltip:hover .tooltiptext {
         visibility: unset;
     }


### PR DESCRIPTION
Added the "editable" class to editable cells and set a white background-color to this class.
So its easier to see which cells can be edited even if there already filled.

![grafik](https://user-images.githubusercontent.com/16044116/135830737-576bd32e-c9e5-4d86-bfc7-068533a66c6c.png)
![grafik](https://user-images.githubusercontent.com/16044116/135830743-443bf1bf-189a-42a0-bda5-d9f887d4ee14.png)
![grafik](https://user-images.githubusercontent.com/16044116/135830748-93edcee4-bda1-49a5-bfbb-2ed209cb25bb.png)


This should fix https://github.com/untitled-team-101/sudoku/issues/10